### PR TITLE
Attempt to fix the ``ping`` behavior change

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -21,6 +21,7 @@ known_third_party = "six, MySQLdb, pkg_resources"
 [check-manifest]
 additional-ignores = [
     "docs/_build/html/_static/*",
+    "docs/_build/html/_static/scripts/*",
     ]
 
 [manifest]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Products.ZMySQLDA change log
 5.1 (unreleased)
 ----------------
 
+- Adjust for ``mysqlclient`` behavior change after version 2.2.0
+  (`#34 <https://github.com/zopefoundation/Products.ZMySQLDA/issues/34>`_)
+
 - Add support for Python 3.12 and 3.13.
 
 - Drop support for Python 3.7.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/html/_static/*
+    docs/_build/html/_static/scripts/*
 
 [isort]
 force_single_line = True

--- a/src/Products/ZMySQLDA/db.py
+++ b/src/Products/ZMySQLDA/db.py
@@ -323,13 +323,24 @@ class DB(TM):
 
     __del__ = close
 
-    def _forceReconnection(self):
+    def _forceReconnection(self, reason=''):
         """ (Re)Connect to database.
+
+        Kwargs:
+            reason (str): A reason for the reconnection, which will be logged.
         """
+        if reason:
+            if reason in hosed_connection:
+                LOG.error('Forcing reconnection: %s' % hosed_connection[
+                    reason])
+            else:
+                LOG.debug('Forcing reconnection, reason: %s.' % reason)
+
         try:  # try to clean up first
             self.db.close()
         except Exception:
             pass
+
         self.db = MySQLdb.connect(**self._kw_args)
         # Newer mysqldb requires ping argument to attmept a reconnect.
         # This setting is persistent, so only needed once per connection.
@@ -533,16 +544,11 @@ class DB(TM):
                 raise
 
             # Hm. maybe the db is hosed.  Let's restart it.
-            if exc.args[0] in hosed_connection:
-                msg = '%s Forcing a reconnect.' % hosed_connection[exc.args[0]]
-                LOG.error(msg)
-            self._forceReconnection()
+            self._forceReconnection(reason=exc.args[0])
             self.db.query(query)
         except ProgrammingError as exc:
             if exc.args[0] in hosed_connection:
-                self._forceReconnection()
-                msg = '%s Forcing a reconnect.' % hosed_connection[exc.args[0]]
-                LOG.error(msg)
+                self._forceReconnection(reason=exc.args[0])
             else:
                 if len(query) > 2000:
                     msg = '%s... (truncated at 2000 chars)' % query[:2000]
@@ -640,15 +646,25 @@ class DB(TM):
         Also called from _register() upon first query.
         """
         try:
+            try:
+                self.db.ping()
+            except OperationalError as exc:
+                # Starting with mysqlclient version 2.2.1 the connection object
+                # ``ping`` method behavior changed. It may raise an exception.
+                # If the connection is broken attempt to reconnect first.
+                if exc.args[0] in hosed_connection:
+                    self._forceReconnection(reason=exc.args[0])
+                else:
+                    raise
+
             self._transaction_begun = True
-            self.db.ping()
             if self._transactions:
                 self._query('BEGIN')
             if self._mysql_lock:
                 self._query("SELECT GET_LOCK('%s',0)" % self._mysql_lock)
-        except Exception:
-            LOG.error('exception during _begin', exc_info=True)
-            raise ConflictError
+        except Exception as exc:
+            LOG.error('Exception during _begin', exc_info=True)
+            raise ConflictError('Database error %s' % exc.args[0])
 
     def _finish(self, *ignored):
         """ Commit a transaction, if transactions are enabled and the

--- a/src/Products/ZMySQLDA/tests/dummy.py
+++ b/src/Products/ZMySQLDA/tests/dummy.py
@@ -12,6 +12,9 @@
 ##############################################################################
 """ Dummy fixtures for testing
 """
+from MySQLdb import OperationalError
+
+
 RESULTS = {'show table status': [['table1', 'engine1', None, None, 5, None,
                                   None, None, None, None, None, None, None,
                                   None, 'my_collation']],
@@ -50,12 +53,14 @@ class FakeConnection:
         self.last_query = None
         self.string_literal_called = False
         self.unicode_literal_called = False
+        self.ping_raises = False
 
         for k, v in kw.items():
             setattr(self, k, v)
 
     def ping(self, *args):
-        pass
+        if self.ping_raises:
+            raise OperationalError(self.ping_raises)
 
     def query(self, sql):
         self.last_query = sql


### PR DESCRIPTION
Fixes #34 

This PR attempts to recover from a stale MySQL/MariaDB database connection encountered during the first phase of the Zope transaction. The ``mysqlclient`` library changed behaviors in version 2.2.1 which means the database connection ``ping`` method can now throw exceptions, which leads to unrecoverable errors in Zope.