### PR TITLE
Re-enable processing GHA additional dependency installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+    - name: Install additional dependencies
+      run: |
+        sudo systemctl start mysql.service
+        echo 'CREATE DATABASE IF NOT EXISTS zmysqldatest;' | mysql -uroot -proot
+        echo "CREATE USER 'zmysqldatest'@'localhost' IDENTIFIED BY 'zmysqldatest';" | mysql -uroot -proot
+        echo "GRANT ALL PRIVILEGES ON zmysqldatest.* TO 'zmysqldatest'@'localhost';" | mysql -uroot -proot
     - name: Install uv + caching
       uses: astral-sh/setup-uv@v5
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ branch = true
 source = ["Products.ZMySQLDA"]
 
 [tool.coverage.report]
-fail_under = 73
+fail_under = 93
 precision = 2
 ignore_errors = true
 show_missing = true


### PR DESCRIPTION
Fixes #38

As already suspected, this is a bug in zope.meta that was introduced in https://github.com/zopefoundation/meta/pull/307.

This was fixed here with the code at https://github.com/zopefoundation/meta/pull/318
